### PR TITLE
Filter feature

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -1,12 +1,15 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.employee.ContainsDepartmentPredicate;
-import seedu.address.model.employee.NameContainsKeywordsPredicate;
 
-import static java.util.Objects.requireNonNull;
-
+/**
+ * Filters employees in ManageHR app whose department(s) contains the argument keyword.
+ * Keyword matching is case-sensitive.
+ */
 public class FilterCommand extends Command {
     public static final String COMMAND_WORD = "filter";
 

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.employee.ContainsDepartmentPredicate;
@@ -28,5 +29,27 @@ public class FilterCommand extends Command {
         model.updateFilteredEmployeeList(predicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_EMPLOYEES_LISTED_OVERVIEW, model.getFilteredEmployeeList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof FilterCommand)) {
+            return false;
+        }
+
+        FilterCommand otherFilterCommand = (FilterCommand) other;
+        return predicate.equals(otherFilterCommand.predicate);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("predicate", predicate)
+                .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.commands;
+
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.employee.ContainsDepartmentPredicate;
+import seedu.address.model.employee.NameContainsKeywordsPredicate;
+
+import static java.util.Objects.requireNonNull;
+
+public class FilterCommand extends Command {
+    public static final String COMMAND_WORD = "filter";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all employees whose departments contain any of "
+            + "the specified keyword (case-sensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD\n"
+            + "Example: " + COMMAND_WORD + " R&D";
+    private final ContainsDepartmentPredicate predicate;
+
+    public FilterCommand(ContainsDepartmentPredicate predicate) {
+        this.predicate = predicate;
+    }
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredEmployeeList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_EMPLOYEES_LISTED_OVERVIEW, model.getFilteredEmployeeList().size()));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -1,0 +1,32 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.FilterCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.employee.ContainsDepartmentPredicate;
+
+/**
+ * Parses input arguments and creates a new FilterCommand object.
+ */
+public class FilterCommandParser implements Parser<FilterCommand> {
+
+    /**
+     * Parses the given {@code String} argument in the context of the FilterCommand
+     * and returns a FilterCommand object for execution.
+     * @param args FilterCommand argument.
+     * @return FilterCommand object for execution.
+     * @throws ParseException if the user inputs does not conform to the expected format.
+     */
+    public FilterCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
+        }
+
+        String departmentKeyword = trimmedArgs;
+
+        return new FilterCommand(new ContainsDepartmentPredicate(departmentKeyword));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ManageHrParser.java
+++ b/src/main/java/seedu/address/logic/parser/ManageHrParser.java
@@ -14,6 +14,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
@@ -76,6 +77,9 @@ public class ManageHrParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case FilterCommand.COMMAND_WORD:
+            return new FilterCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/model/employee/ContainsDepartmentPredicate.java
+++ b/src/main/java/seedu/address/model/employee/ContainsDepartmentPredicate.java
@@ -1,0 +1,38 @@
+package seedu.address.model.employee;
+
+import seedu.address.commons.util.ToStringBuilder;
+
+import java.util.function.Predicate;
+
+public class ContainsDepartmentPredicate implements Predicate<Employee> {
+    private final String keyword;
+
+    public ContainsDepartmentPredicate(String keyword) {
+        this.keyword = keyword;
+    }
+
+    @Override
+    public boolean test(Employee employee) {
+        return employee.getDepartments().contains(keyword);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ContainsDepartmentPredicate)) {
+            return false;
+        }
+
+        ContainsDepartmentPredicate otherContainsDepartmentPredicate = (ContainsDepartmentPredicate) other;
+        return keyword.equals(otherContainsDepartmentPredicate.keyword);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keyword", keyword).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/employee/ContainsDepartmentPredicate.java
+++ b/src/main/java/seedu/address/model/employee/ContainsDepartmentPredicate.java
@@ -1,9 +1,13 @@
 package seedu.address.model.employee;
 
-import seedu.address.commons.util.ToStringBuilder;
-
 import java.util.function.Predicate;
 
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.department.Department;
+
+/**
+ * Tests that an {@code Employee}'s {@code Name} matches the keyword given.
+ */
 public class ContainsDepartmentPredicate implements Predicate<Employee> {
     private final String keyword;
 
@@ -13,7 +17,7 @@ public class ContainsDepartmentPredicate implements Predicate<Employee> {
 
     @Override
     public boolean test(Employee employee) {
-        return employee.getDepartments().contains(keyword);
+        return employee.getDepartments().contains(new Department(keyword));
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -1,0 +1,86 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_EMPLOYEES_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalEmployees.ALICE;
+import static seedu.address.testutil.TypicalEmployees.BENSON;
+import static seedu.address.testutil.TypicalEmployees.DANIEL;
+import static seedu.address.testutil.TypicalEmployees.getTypicalManageHr;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.employee.ContainsDepartmentPredicate;
+
+public class FilterCommandTest {
+    private Model model = new ModelManager(getTypicalManageHr(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalManageHr(), new UserPrefs());
+
+    @Test
+    public void execute_noEmployeesFound() {
+        String expectedMessage = String.format(MESSAGE_EMPLOYEES_LISTED_OVERVIEW, 0);
+        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate(" ");
+        FilterCommand command = new FilterCommand(predicate);
+        expectedModel.updateFilteredEmployeeList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredEmployeeList());
+    }
+
+    @Test
+    public void execute_multipleEmployeesFound() {
+        String expectedMessage = String.format(MESSAGE_EMPLOYEES_LISTED_OVERVIEW, 3);
+        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate("investment");
+        FilterCommand command = new FilterCommand(predicate);
+        expectedModel.updateFilteredEmployeeList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, BENSON, DANIEL), model.getFilteredEmployeeList());
+
+        expectedMessage = String.format(MESSAGE_EMPLOYEES_LISTED_OVERVIEW, 1);
+        predicate = new ContainsDepartmentPredicate("logistics");
+        command = new FilterCommand(predicate);
+        expectedModel.updateFilteredEmployeeList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(BENSON), model.getFilteredEmployeeList());
+    }
+
+    @Test
+    public void equals() {
+        ContainsDepartmentPredicate firstPredicate = new ContainsDepartmentPredicate("first");
+        ContainsDepartmentPredicate secondPredicate = new ContainsDepartmentPredicate("second");
+
+        FilterCommand filterFirstCommand = new FilterCommand(firstPredicate);
+        FilterCommand filterSecondCommand = new FilterCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(filterFirstCommand.equals(filterFirstCommand));
+
+        // same values -> returns true
+        FilterCommand findFirstCommandCopy = new FilterCommand(firstPredicate);
+        assertTrue(filterFirstCommand.equals(findFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(filterFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(filterFirstCommand.equals(null));
+
+        // different employee -> returns false
+        assertFalse(filterFirstCommand.equals(filterSecondCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate("keyword");
+        FilterCommand findCommand = new FilterCommand(predicate);
+        String expected = FilterCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
+        assertEquals(expected, findCommand.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -1,0 +1,26 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FilterCommand;
+import seedu.address.model.employee.ContainsDepartmentPredicate;
+
+public class FilterCommandParserTest {
+    private FilterCommandParser parser = new FilterCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, " ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FilterCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFilterCommand() {
+        FilterCommand expectedFilterCommand = new FilterCommand(new ContainsDepartmentPredicate("R&D"));
+        assertParseSuccess(parser, "R&D", expectedFilterCommand);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ManageHrParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ManageHrParserTest.java
@@ -18,10 +18,12 @@ import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.employee.ContainsDepartmentPredicate;
 import seedu.address.model.employee.Employee;
 import seedu.address.model.employee.NameContainsKeywordsPredicate;
 import seedu.address.testutil.EditEmployeeDescriptorBuilder;
@@ -73,6 +75,13 @@ public class ManageHrParserTest {
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+    }
+
+    @Test
+    public void parseCommand_filter() throws Exception {
+        String keyword = "R&D";
+        FilterCommand command = (FilterCommand) parser.parseCommand(FilterCommand.COMMAND_WORD + " " + keyword);
+        assertEquals(new FilterCommand(new ContainsDepartmentPredicate(keyword)), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/employee/ContainsDepartmentPredicateTest.java
+++ b/src/test/java/seedu/address/model/employee/ContainsDepartmentPredicateTest.java
@@ -1,0 +1,38 @@
+package seedu.address.model.employee;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.EmployeeBuilder;
+
+public class ContainsDepartmentPredicateTest {
+    @Test
+    public void test_containsDepartment_returnsTrue() {
+        // One keyword
+        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate("R&D");
+        assertTrue(predicate.test(new EmployeeBuilder().withDepartments("R&D").build()));
+    }
+
+    @Test
+    public void test_doesNotContainDepartment_returnsFalse() {
+        // Zero keywords
+        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate(" ");
+        assertFalse(predicate.test(new EmployeeBuilder().withDepartments("R&D").build()));
+
+        // Non-matching keyword
+        predicate = new ContainsDepartmentPredicate("R&D");
+        assertFalse(predicate.test(new EmployeeBuilder().withDepartments("Finance").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        String keyword = "Finance";
+        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate(keyword);
+
+        String expected = ContainsDepartmentPredicate.class.getCanonicalName() + "{keyword=" + keyword + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}


### PR DESCRIPTION
Implemented `filter` feature to filter by departments
- created new test classes/cases
- all test cases passed

Currently can only filter by 1 keyword
eg. `filter R&D`

Planning to make the following enhancements (dependent on time):
- parameter to accept multiple keywords
- implement prefix to filter by other parameters
  - eg. `filter s/4000` shows employees with salary 4000 and below