### PR TITLE
Fix bug with code and update UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -31,7 +31,7 @@ Table of Contents
 
    * `list` : Lists all employees.
 
-   * `add n/John doe p/91234567 e/example@example.com a/1 Lower Kent Ridge Road d/SoC HR` : Quickly add an employee:
+   * `add n/John doe p/91234567 e/example@example.com a/1 Lower Kent Ridge Road s/4000 l/12 r/manager d/SoC HR` : Quickly add an employee:
 
    * `delete 3` : Deletes the 3rd employee shown in the current list.
 
@@ -67,6 +67,47 @@ Table of Contents
 * If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.
 </div>
 
+## Feature 1: Manager-Subordinate Relationships
+
+### Overview
+
+Our application includes a powerful manager-subordinate feature that enables users to define and manage hierarchical 
+relationships within their organization. This feature is designed to streamline the management of employees between 
+supervisors and subordinates.
+
+### Constraints
+
+1. Only employees with `manager` role can be in charge of other employees.
+2. Each employee must either be `manager` and `subordinate` but not both.
+2. Both employees that are either `manager` or `subordinate` can have multiple `manager` in charge of them.
+3. An employee could have no designated "manager" responsible for overseeing them.
+4. A `manager` employee could not edit their `role` and `name` attribute when he or she is in charge of any subordinates.
+
+### Usage Instructions
+
+To set up manager-subordinate relationships, follow these steps:
+
+#### Enrolling a New Employee with Manager-Subordinate Relationships
+
+When enrolling a new employee in ManageHR, you can also establish manager-subordinate relationships. Follow these steps:
+1. Include `r/ROLE` into `add` command, where `ROLE` could either be `manager` or `subordinate`. This is a compulsory field where each employee must either be `manager` or `subordinate`.
+2. Include `m/MANAGER NAME…` into `add` command. This is an optional field. Note that you can have multiple managers in charge of this employee or none at all.
+3.  `m/MANAGER NAME…` represents the managers who are currently in charge of the said employee.
+
+#### Editing an Existing Employee with Manager-Subordinate Relationships
+When editing an existing employee in ManageHR, you can also establish or modify manager-subordinate relationships. Follow these steps:
+1. Include `r/ROLE` into `edit` command to change the current `role` of the employee.
+
+    - The employee can only change his or her `role` from `manager` to `subordinate` only if he or she has no employees under his or her supervision.
+    - The name of the employee can only be edited if he or she is a `manager` with no employees under his or her supervision.
+2. Include `m/MANAGER NAME…` into the `edit` command. This will place the employee to be under that `manager`.
+    - The `MANAGER NAME` stated must correspond with an existing employee with the same name and is also a `manager`.
+
+#### Deleting an Existing Employee with Manager-Subordinate Relationships
+hen deleting an existing employee from ManageHR, you will need to account for the manager-subordinate relationships. Follow these steps:
+1. The employee to be deleted must not be in charge of any employees.
+    - If the employee to be deleted has employees under him, all the employees under said employee must be reassigned.
+
 ### Viewing help : `help`
 
 Shows a message explaining how to access the user guide.
@@ -95,32 +136,36 @@ Expected outputs:
 
 Adds an employee to ManageHR’s entries.
 
-Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS s/SALARY l/LEAVE d/DEPARTMENT`
+Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS s/SALARY l/LEAVE r/ROLE d/DEPARTMENT… m/MANAGER NAME…`
 - Adds an employee with the above fields
 - All fields must be provided
 
 Examples:
-* `add n/Johnny p/91242712 e/johnnysins@gmail.com a/Johnny street, block 69, #05-05 s/5300 l/14 d/ R&D`
-* `add n/Elon p/12345678 e/elonma@gmail.com a/Elon street, block 140, #20-01 s/2100 l/21 d/R&D`
+* `add n/Johnny p/91242712 e/johnnysins@gmail.com a/Johnny street, block 69, #05-05 s/5300 l/14 r/subordinate d/ R&D m/ Alex Yeoh`
+* `add n/Elon p/12345678 e/elonma@gmail.com a/Elon street, block 140, #20-01 s/2100 l/21 r/manager d/R&D`
 
 Acceptable values for each parameter:
 
-| Parameters | Accepted input |
-| --- |  |
-| `NAME` | Alphabets |
-| `PHONE_NUMBER` | 8 digits |
-| `EMAIL` | Email with the pattern x@x.com where ‘x’ are alphanumerics |
-| `ADDRESS` | Alphanumerics and ascii characters i.e. #, - |
-| `SALARY` | Numerals |
-| `LEAVE` | Numerals |
-| `DEPARTMENT` | Alphabets and ascii characters i.e. &, - |
+| Parameters | Accepted input                                               |
+| --- |--------------------------------------------------------------|
+| `NAME` | Alphabets                                                    |
+| `PHONE_NUMBER` | 8 digits                                                     |
+| `EMAIL` | Email with the pattern x@x.com where ‘x’ are alphanumerics   |
+| `ADDRESS` | Alphanumerics and ascii characters i.e. #, -                 |
+| `SALARY` | Numerals                                                     |
+| `LEAVE` | Numerals                                                     |
+| `ROLE` | `manager` or `subordinate` (Case-insensitive)                | 
+| `DEPARTMENT` | Alphabets and ascii characters i.e. &, -                     |
 
 Expected outputs:
 
-| Outcome | Output                                                                                                             |
-| --- |--------------------------------------------------------------------------------------------------------------------|
-| **Success** | Employee added! Johnny \| 12345678 \| johnnysins@gmail.com \| Johnny Street, block 69, #05-05 \| 5300 \| 14 \| R&D |
-| **Fail** | Please check the parameter inputs                                                                                  |
+| Outcome | Output                                                                                                                            |
+| --- |-----------------------------------------------------------------------------------------------------------------------------------|
+| **Success** | Employee added! Johnny \| 12345678 \| johnnysins@gmail.com \| Johnny Street, block 69, #05-05 \| 5300 \| 14 \| subordinate \| R&D |
+| **Fail** | Please check the parameter inputs                                                                                                 |
+
+Constraints:
+* [Manager-subordinate relationship](#enrolling-a-new-employee-with-manager-subordinate-relationships)
 
 ### Listing all employees : `list`
 
@@ -148,7 +193,7 @@ Fail:
 
 Edits an existing employee in the address book.
 
-Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [s/SALARY] [l/LEAVE] [d/DEPARTMENT]​`
+Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [s/SALARY] [l/LEAVE] [r/ROLE] [m/MANAGER NAME]… [d/DEPARTMENT]…​`
 
 * Edits the employee at the specified `INDEX`. The index refers to the index number shown in the displayed employee list.
 * At least one of the optional fields must be provided.
@@ -157,7 +202,10 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [s/SALARY] [l/LEAVE
 Examples:
 *  `edit 1 p/91234567 e/johnsimmons@gmail.com` Edits the phone number and email address of the 1st employee to be `91234567` and `johnsimmons@gmail.com` respectively.
 
-### Locating employee by name: `find` `[Coming Soon]`
+Constraints:
+* [Manager-subordinate relationship](#editing-an-existing-employee-with-manager-subordinate-relationships)
+
+### Locating employee by name: `find`
 
 Finds people whose names contain any of the given keywords.
 
@@ -196,6 +244,8 @@ Fail:
 * If the employee to be deleted does not exist, a warning will be displayed.
 “The employee you’re trying to delete does not exist.”
 
+Constraints:
+* [Manager-subordinate relationship](#deleting-an-existing-employee-with-manager-subordinate-relationships)
   
 ### Exiting the program : `exit`
 
@@ -212,12 +262,8 @@ AddressBook data are saved in the hard disk automatically after any command that
 AddressBook data are saved automatically as a JSON file `[JAR file location]/data/addressbook.json`. Advanced users are welcome to update data directly by editing that data file.
 
 <div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
-If your changes to the data file makes its format invalid, AddressBook will discard all data and start with an empty data file at the next run. Hence, it is recommended to take a backup of the file before editing it.
+If your changes to the data file makes its format invalid, ManageHR will discard all data and start with an empty data file at the next run. Hence, it is recommended to take a backup of the file before editing it.
 </div>
-
-### Archiving data files `[coming in v2.0]`
-
-_Details coming soon ..._
 
 --------------------------------------------------------------------------------------------------------------------
 
@@ -246,11 +292,12 @@ Now, your data should be successfully transferred to the new computer.
 
 ## Command summary
 
-Action | Format, Examples
---------|------------------
-**Add** | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS s/SALARY l/LEAVE d/DEPARTMENT` <br> e.g., `add n/Johnny p/91242712 e/johnnysins@gmail.com a/Johnny street, block 69, #05-05 s/14000 l/21 d/R&D`
-**Exit** | `exit`
-**Delete** | `delete INDEX`<br> e.g., `delete 4`
-**Edit** | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [d/DEPARTMENT]`<br> e.g.,`edit 1 p/91234567 e/johnsimmons@gmail.com`
-**List** | `list`
-**Help** | `help`
+Action | Format, Examples                                                                                                                                                                                                                                |
+--------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+**Add** | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS s/SALARY l/LEAVE r/ROLE d/DEPARTMENT… m/MANAGER NAME…` <br> e.g., `add n/Johnny p/91242712 e/johnnysins@gmail.com a/Johnny street, block 69, #05-05 s/5300 l/14 r/subordinate d/ R&D m/ Alex Yeoh` |
+**Exit** | `exit`                                                                                                                                                                                                                                          |
+**Delete** | `delete INDEX`<br> e.g., `delete 4`                                                                                                                                                                                                             |
+**Edit** | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [s/SALARY] [l/LEAVE] [r/ROLE] [m/MANAGER NAME]… [d/DEPARTMENT]…`<br> e.g.,`edit 1 p/91234567 e/johnsimmons@gmail.com`                                                                      |
+**List** | `list`                                                                                                                                                                                                                                          |
+**Help** | `help`                                                                                                                                                                                                                                          |
+**Find** | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find alex david`                                                                                                                                                                                      |

--- a/src/main/java/seedu/address/logic/commands/exceptions/CommandException.java
+++ b/src/main/java/seedu/address/logic/commands/exceptions/CommandException.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands.exceptions;
 
 /**
- * Represents an error which occurs during execution of a {@link Command}.
+ * Represents an error which occurs during execution of a {@code Command}.
  */
 public class CommandException extends Exception {
     public CommandException(String message) {

--- a/src/main/java/seedu/address/model/ManageHr.java
+++ b/src/main/java/seedu/address/model/ManageHr.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.employee.Employee;
 import seedu.address.model.employee.UniqueEmployeeList;
 import seedu.address.model.employee.exceptions.SubordinatePresentException;
@@ -94,9 +95,9 @@ public class ManageHr implements ReadOnlyManageHr {
      * @throws SubordinatePresentException If the original employee manages subordinates, preventing the update.
      * @throws SupervisorNotFoundException If the target employee is the supervisor of the editedEmployee.
      */
-    public void setEmployee(Employee target, Employee editedEmployee) {
+    public void setEmployee(Employee target, Employee editedEmployee) throws CommandException {
         requireNonNull(editedEmployee);
-        if (employees.hasSubordinates(target)) {
+        if (!target.isSameEmployee(editedEmployee) && employees.hasSubordinates(target)) {
             throw new SubordinatePresentException();
         }
         if (!employees.containsManager(editedEmployee)) {
@@ -105,8 +106,15 @@ public class ManageHr implements ReadOnlyManageHr {
         if (target.isSupervisorOf(editedEmployee)) {
             throw new SupervisorNotFoundException();
         }
-
+        if (target.isSameEmployee(editedEmployee) && !hasPermissibleEdits(target, editedEmployee)
+                && employees.hasSubordinates(target)) {
+            throw new CommandException("Name and role should not be edited when he is still managing other employees");
+        }
         employees.setEmployee(target, editedEmployee);
+    }
+
+    private boolean hasPermissibleEdits(Employee target, Employee editedEmployee) {
+        return !target.isSameEmployee(editedEmployee) || target.hasSameRole(editedEmployee);
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.employee.Employee;
 
 /**
@@ -74,7 +75,7 @@ public interface Model {
      * {@code target} must exist in ManageHR.
      * The employee identity of {@code editedEmployee} must not be the same as another existing employee in ManageHR.
      */
-    void setEmployee(Employee target, Employee editedEmployee);
+    void setEmployee(Employee target, Employee editedEmployee) throws CommandException;
 
     /** Returns an unmodifiable view of the filtered employee list */
     ObservableList<Employee> getFilteredEmployeeList();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.employee.Employee;
 
 /**
@@ -105,7 +106,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void setEmployee(Employee target, Employee editedEmployee) {
+    public void setEmployee(Employee target, Employee editedEmployee) throws CommandException {
         requireAllNonNull(target, editedEmployee);
 
         manageHr.setEmployee(target, editedEmployee);

--- a/src/main/java/seedu/address/model/employee/Employee.java
+++ b/src/main/java/seedu/address/model/employee/Employee.java
@@ -139,6 +139,16 @@ public class Employee {
     }
 
     /**
+     * Checks if this employee has the same role as the given employee.
+     *
+     * @param employee The employee to compare roles with.
+     * @return true if this employee has the same role as the given employee, false otherwise.
+     */
+    public boolean hasSameRole(Employee employee) {
+        return role.equals(employee.getRole());
+    }
+
+    /**
      * Returns true if both employees have the same identity and data fields.
      * This defines a stronger notion of equality between two employees.
      */

--- a/src/main/java/seedu/address/model/employee/UniqueEmployeeList.java
+++ b/src/main/java/seedu/address/model/employee/UniqueEmployeeList.java
@@ -108,18 +108,19 @@ public class UniqueEmployeeList implements Iterable<Employee> {
         if (!target.isSameEmployee(editedEmployee) && contains(editedEmployee)) {
             throw new DuplicateEmployeeException();
         }
-        if (!containsManager(editedEmployee)) {
-            throw new SupervisorNotFoundException();
-        }
-        if (hasSubordinates(target)) {
+        if (!target.isSameEmployee(editedEmployee) && hasSubordinates(target)) {
             throw new SubordinatePresentException();
         }
         if (target.isSupervisorOf(editedEmployee)) {
             throw new SupervisorNotFoundException();
         }
+        if (!containsManager(editedEmployee)) {
+            throw new SupervisorNotFoundException();
+        }
 
         internalList.set(index, editedEmployee);
     }
+
 
     /**
      * Removes the equivalent employee from the list.

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.EditCommand.EditEmployeeDescriptor;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.ManageHr;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -36,7 +37,7 @@ public class EditCommandTest {
     private Model model = new ModelManager(getTypicalManageHr(), new UserPrefs());
 
     @Test
-    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+    public void execute_allFieldsSpecifiedUnfilteredList_success() throws CommandException {
         Employee editedEmployee = new EmployeeBuilder().build();
         EditEmployeeDescriptor descriptor = new EditEmployeeDescriptorBuilder(editedEmployee).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_EMPLOYEE, descriptor);
@@ -51,7 +52,7 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_someFieldsSpecifiedUnfilteredList_success() {
+    public void execute_someFieldsSpecifiedUnfilteredList_success() throws CommandException {
         Index indexLastEmployee = Index.fromOneBased(model.getFilteredEmployeeList().size());
         Employee lastEmployee = model.getFilteredEmployeeList().get(indexLastEmployee.getZeroBased());
 
@@ -86,7 +87,7 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_filteredList_success() {
+    public void execute_filteredList_success() throws CommandException {
         showEmployeeAtIndex(model, INDEX_FIRST_EMPLOYEE);
 
         Employee employeeInFilteredList = model.getFilteredEmployeeList().get(INDEX_FIRST_EMPLOYEE.getZeroBased());

--- a/src/test/java/seedu/address/model/ManageHrTest.java
+++ b/src/test/java/seedu/address/model/ManageHrTest.java
@@ -5,8 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DEPARTMENT_LOGISTIC;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ROLE_BOB;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalEmployees.ALICE;
+import static seedu.address.testutil.TypicalEmployees.BENSON;
 import static seedu.address.testutil.TypicalEmployees.getTypicalManageHr;
 
 import java.util.Arrays;
@@ -18,8 +21,10 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.employee.Employee;
 import seedu.address.model.employee.exceptions.DuplicateEmployeeException;
+import seedu.address.model.employee.exceptions.SubordinatePresentException;
 import seedu.address.testutil.EmployeeBuilder;
 
 public class ManageHrTest {
@@ -53,6 +58,20 @@ public class ManageHrTest {
         ManageHrStub newData = new ManageHrStub(newPeople);
 
         assertThrows(DuplicateEmployeeException.class, () -> manageHr.resetData(newData));
+    }
+
+    @Test
+    public void setEmployee_employeeWithSubordinatesChangesName_throwsSubordinatePresentException() {
+        ManageHr typicalManageHr = getTypicalManageHr();
+        Employee editedBenson = new EmployeeBuilder(BENSON).withName(VALID_NAME_BOB).build();
+        assertThrows(SubordinatePresentException.class, () -> typicalManageHr.setEmployee(BENSON, editedBenson));
+    }
+
+    @Test
+    public void setEmployee_employeeWithSubordinatesChangesRole_throwsCommandException() {
+        ManageHr typicalManageHr = getTypicalManageHr();
+        Employee editedBenson = new EmployeeBuilder(BENSON).withRole(VALID_ROLE_BOB).build();
+        assertThrows(CommandException.class, () -> typicalManageHr.setEmployee(BENSON, editedBenson));
     }
 
     @Test


### PR DESCRIPTION
Ensure `manager` employee with subordinates can still edit their salary, email, department, supervisors, leave, phone and address etc. 
However, their name and role cannot be edited till they no longer have any subordinates under them.

User guide is also updated.