### PR TITLE
Enhance filter feature with salary prefix

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DEPARTMENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SALARY;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,9 +26,10 @@ public class FilterCommandParser implements Parser<FilterCommand> {
      */
     public FilterCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_DEPARTMENT);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_SALARY, PREFIX_DEPARTMENT);
 
         List<String> departmentNames = new ArrayList<>();
+        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate();
 
         if (argMultimap.getValue(PREFIX_DEPARTMENT).isPresent()) {
             departmentNames = argMultimap.getAllValues(PREFIX_DEPARTMENT);
@@ -38,8 +40,14 @@ public class FilterCommandParser implements Parser<FilterCommand> {
             if (departmentNames.get(0).isEmpty()) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
             }
+
+            predicate.setDepartment(departmentNames.get(0));
         }
 
-        return new FilterCommand(new ContainsDepartmentPredicate(departmentNames.get(0)));
+        if (argMultimap.getValue(PREFIX_SALARY).isPresent()) {
+            predicate.setSalary(ParserUtil.parseSalary(argMultimap.getValue(PREFIX_SALARY).get()));
+        }
+
+        return new FilterCommand(predicate);
     }
 }

--- a/src/main/java/seedu/address/model/employee/ContainsDepartmentPredicate.java
+++ b/src/main/java/seedu/address/model/employee/ContainsDepartmentPredicate.java
@@ -9,8 +9,8 @@ import seedu.address.model.name.DepartmentName;
  * Tests that an {@code Employee}'s {@code Name} matches the keyword given.
  */
 public class ContainsDepartmentPredicate implements Predicate<Employee> {
-    private String keyword;
-    private Salary salary;
+    private String keyword = "";
+    private Salary salary = new Salary("0");
 
     public ContainsDepartmentPredicate() {
     }
@@ -20,14 +20,14 @@ public class ContainsDepartmentPredicate implements Predicate<Employee> {
         boolean departmentResult = true;
         boolean salaryResult = true;
 
-        if (keyword != null) {
+        if (keyword != "") {
             departmentResult = employee.getDepartments().contains(new DepartmentName(keyword)) ? true : false;
         }
 
-        if (salary != null) {
-            Integer actual = Integer.valueOf(employee.getSalary().toString());
-            Integer test = Integer.valueOf(salary.toString());
-            salaryResult = actual <= test ? true : false;
+        if (salary.value != "0") {
+            Integer actualValue = Integer.valueOf(employee.getSalary().toString());
+            Integer filterValue = Integer.valueOf(salary.toString());
+            salaryResult = actualValue <= filterValue ? true : false;
         }
 
         return departmentResult && salaryResult;
@@ -53,11 +53,15 @@ public class ContainsDepartmentPredicate implements Predicate<Employee> {
         }
 
         ContainsDepartmentPredicate otherContainsDepartmentPredicate = (ContainsDepartmentPredicate) other;
-        return keyword.equals(otherContainsDepartmentPredicate.keyword);
+        return keyword.equals(otherContainsDepartmentPredicate.keyword)
+                && salary.equals(otherContainsDepartmentPredicate.salary);
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).add("keyword", keyword).toString();
+        return new ToStringBuilder(this)
+                .add("keyword", keyword)
+                .add("salary", salary)
+                .toString();
     }
 }

--- a/src/main/java/seedu/address/model/employee/ContainsDepartmentPredicate.java
+++ b/src/main/java/seedu/address/model/employee/ContainsDepartmentPredicate.java
@@ -9,15 +9,36 @@ import seedu.address.model.name.DepartmentName;
  * Tests that an {@code Employee}'s {@code Name} matches the keyword given.
  */
 public class ContainsDepartmentPredicate implements Predicate<Employee> {
-    private final String keyword;
+    private String keyword;
+    private Salary salary;
 
-    public ContainsDepartmentPredicate(String keyword) {
-        this.keyword = keyword;
+    public ContainsDepartmentPredicate() {
     }
 
     @Override
     public boolean test(Employee employee) {
-        return employee.getDepartments().contains(new DepartmentName(keyword));
+        boolean departmentResult = true;
+        boolean salaryResult = true;
+
+        if (keyword != null) {
+            departmentResult = employee.getDepartments().contains(new DepartmentName(keyword)) ? true : false;
+        }
+
+        if (salary != null) {
+            Integer actual = Integer.valueOf(employee.getSalary().toString());
+            Integer test = Integer.valueOf(salary.toString());
+            salaryResult = actual <= test ? true : false;
+        }
+
+        return departmentResult && salaryResult;
+    }
+
+    public void setDepartment(String keyword) {
+        this.keyword = keyword;
+    }
+
+    public void setSalary(Salary salary) {
+        this.salary = salary;
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -27,7 +27,8 @@ public class FilterCommandTest {
     @Test
     public void execute_noEmployeesFound() {
         String expectedMessage = String.format(MESSAGE_EMPLOYEES_LISTED_OVERVIEW, 0);
-        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate("A");
+        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate();
+        predicate.setDepartment("A");
         FilterCommand command = new FilterCommand(predicate);
         expectedModel.updateFilteredEmployeeList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -37,22 +38,28 @@ public class FilterCommandTest {
     @Test
     public void execute_multipleEmployeesFound() {
         String expectedMessage = String.format(MESSAGE_EMPLOYEES_LISTED_OVERVIEW, 3);
-        FilterCommand command = new FilterCommand(new ContainsDepartmentPredicate("investment"));
-        expectedModel.updateFilteredEmployeeList(new ContainsDepartmentPredicate("investment"));
+        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate();
+        predicate.setDepartment("investment");
+        FilterCommand command = new FilterCommand(predicate);
+        expectedModel.updateFilteredEmployeeList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(ALICE, BENSON, DANIEL), model.getFilteredEmployeeList());
 
         expectedMessage = String.format(MESSAGE_EMPLOYEES_LISTED_OVERVIEW, 1);
-        command = new FilterCommand(new ContainsDepartmentPredicate("logistics"));
-        expectedModel.updateFilteredEmployeeList(new ContainsDepartmentPredicate("logistics"));
+        predicate = new ContainsDepartmentPredicate();
+        predicate.setDepartment("logistics");
+        command = new FilterCommand(predicate);
+        expectedModel.updateFilteredEmployeeList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(BENSON), model.getFilteredEmployeeList());
     }
 
     @Test
     public void equals() {
-        ContainsDepartmentPredicate firstPredicate = new ContainsDepartmentPredicate("first");
-        ContainsDepartmentPredicate secondPredicate = new ContainsDepartmentPredicate("second");
+        ContainsDepartmentPredicate firstPredicate = new ContainsDepartmentPredicate();
+        firstPredicate.setDepartment("first");
+        ContainsDepartmentPredicate secondPredicate = new ContainsDepartmentPredicate();
+        secondPredicate.setDepartment("second");
 
         FilterCommand filterFirstCommand = new FilterCommand(firstPredicate);
         FilterCommand filterSecondCommand = new FilterCommand(secondPredicate);
@@ -76,7 +83,8 @@ public class FilterCommandTest {
 
     @Test
     public void toStringMethod() {
-        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate("keyword");
+        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate();
+        predicate.setDepartment("keyword");
         FilterCommand filterCommand = new FilterCommand(predicate);
         String expected = FilterCommand.class.getCanonicalName() + "{predicate="
                 + predicate + "}";

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FilterCommand;
 import seedu.address.model.employee.ContainsDepartmentPredicate;
+import seedu.address.model.employee.Salary;
 
 public class FilterCommandParserTest {
     private FilterCommandParser parser = new FilterCommandParser();
@@ -26,12 +27,14 @@ public class FilterCommandParserTest {
     @Test
     public void parse_validArgs_returnsFilterCommand() {
         String userInput = DEPARTMENT_DESC_INVESTMENT;
-        FilterCommand expectedFilterCommand =
-                new FilterCommand(new ContainsDepartmentPredicate(VALID_DEPARTMENT_INVESTMENT));
+        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate();
+        predicate.setDepartment(VALID_DEPARTMENT_INVESTMENT);
+        FilterCommand expectedFilterCommand = new FilterCommand(predicate);
         assertParseSuccess(parser, userInput, expectedFilterCommand);
 
         userInput = DEPARTMENT_DESC_LOGISTIC;
-        expectedFilterCommand = new FilterCommand(new ContainsDepartmentPredicate(VALID_DEPARTMENT_LOGISTIC));
+        predicate.setDepartment(VALID_DEPARTMENT_LOGISTIC);
+        expectedFilterCommand = new FilterCommand(predicate);
         assertParseSuccess(parser, userInput, expectedFilterCommand);
     }
 
@@ -40,5 +43,30 @@ public class FilterCommandParserTest {
         String userInput = DEPARTMENT_DESC_INVESTMENT + DEPARTMENT_DESC_LOGISTIC;
         assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 FilterCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validSalaryArgs_returnsFilterCommand() {
+        String userInput = " s/4000";
+        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate();
+        predicate.setSalary(new Salary("4000"));
+        FilterCommand expectedFilterCommand = new FilterCommand(predicate);
+        assertParseSuccess(parser, userInput, expectedFilterCommand);
+
+        userInput = " s/8000";
+        predicate = new ContainsDepartmentPredicate();
+        predicate.setSalary(new Salary("8000"));
+        expectedFilterCommand = new FilterCommand(predicate);
+        assertParseSuccess(parser, userInput, expectedFilterCommand);
+    }
+
+    @Test
+    public void parse_validSalaryAndDepartmentArgs_returnsFilterCommand() {
+        String userInput = " d/R&D s/2000";
+        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate();
+        predicate.setDepartment("R&D");
+        predicate.setSalary(new Salary("2000"));
+        FilterCommand expectedFilterCommand = new FilterCommand(predicate);
+        assertParseSuccess(parser, userInput, expectedFilterCommand);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ManageHrParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ManageHrParserTest.java
@@ -82,7 +82,9 @@ public class ManageHrParserTest {
     public void parseCommand_filter() throws Exception {
         String keyword = "d/R&D";
         FilterCommand command = (FilterCommand) parser.parseCommand(FilterCommand.COMMAND_WORD + " " + keyword);
-        assertEquals(new FilterCommand(new ContainsDepartmentPredicate("R&D")), command);
+        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate();
+        predicate.setDepartment("R&D");
+        assertEquals(new FilterCommand(predicate), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/employee/ContainsDepartmentPredicateTest.java
+++ b/src/test/java/seedu/address/model/employee/ContainsDepartmentPredicateTest.java
@@ -12,27 +12,52 @@ public class ContainsDepartmentPredicateTest {
     @Test
     public void test_containsDepartment_returnsTrue() {
         // One keyword
-        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate("R&D");
-        assertTrue(predicate.test(new EmployeeBuilder().withDepartments("R&D").build()));
+        String keyword = "R&D";
+        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate();
+        predicate.setDepartment(keyword);
+        assertTrue(predicate.test(new EmployeeBuilder().withDepartments(keyword).build()));
     }
 
     @Test
     public void test_doesNotContainDepartment_returnsFalse() {
         // Zero keywords
-        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate(" ");
+        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate();
+        predicate.setDepartment(" ");
         assertFalse(predicate.test(new EmployeeBuilder().withDepartments("R&D").build()));
 
         // Non-matching keyword
-        predicate = new ContainsDepartmentPredicate("R&D");
+        predicate = new ContainsDepartmentPredicate();
+        predicate.setDepartment("R&D");
         assertFalse(predicate.test(new EmployeeBuilder().withDepartments("Finance").build()));
+    }
+
+    @Test
+    public void test_containsSalary_returnsTrue() {
+        String salary = "4000";
+        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate();
+        predicate.setSalary(new Salary(salary));
+        assertTrue(predicate.test(new EmployeeBuilder().withSalary(salary).build()));
+    }
+
+    @Test
+    public void test_doesNotContainSalary_returnsFalse() {
+        // 4000 <= 2000 return false
+        String salary = "2000";
+        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate();
+        predicate.setSalary(new Salary(salary));
+        assertFalse(predicate.test(new EmployeeBuilder().withSalary("4000").build()));
     }
 
     @Test
     public void toStringMethod() {
         String keyword = "Finance";
-        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate(keyword);
+        String salary = "2000";
+        ContainsDepartmentPredicate predicate = new ContainsDepartmentPredicate();
+        predicate.setDepartment(keyword);
+        predicate.setSalary(new Salary(salary));
 
-        String expected = ContainsDepartmentPredicate.class.getCanonicalName() + "{keyword=" + keyword + "}";
+        String expected = ContainsDepartmentPredicate.class.getCanonicalName() + "{keyword=" + keyword
+                + ", salary=" + salary + "}";
         assertEquals(expected, predicate.toString());
     }
 }


### PR DESCRIPTION
- able to take in salary prefix in addition to department prefix
- filters salary that is <= to the specified input
   - eg. `filter s/4000` shows employees with salary <= 4000
- works in parallel with department prefix
   - eg. `filter d/R&D s/4000`  shows employees from R&D department __and__ have salary <= 4000

Completes task 2 in #67 