### PR TITLE
Fix bug stopping ManageHR from launch

### DIFF
--- a/src/main/java/seedu/address/model/ManageHr.java
+++ b/src/main/java/seedu/address/model/ManageHr.java
@@ -152,6 +152,28 @@ public class ManageHr implements ReadOnlyManageHr {
     }
 
     /**
+     * Adds an employee to the internal list without applying constraints.
+     * This method is intended for use when adding an employee retrieved from storage,
+     * where constraints related to the supervisor-subordinate relationship are not enforced.
+     *
+     * @param employee The employee to be added. Must not be {@code null}.
+     */
+    public void addEmployeeFromStorageWithoutConstraints(Employee employee) {
+        requireNonNull(employee);
+        updateDepartments(employee);
+        employees.addWithoutConstraints(employee);
+    }
+
+    /**
+     * Enforces constraints on the internal list of employees.
+     * This method ensures that constraints related to the supervisor-subordinate relationship
+     * are applied to the internal list of employees.
+     */
+    public void enforceConstraints() {
+        employees.enforceConstraints();
+    }
+
+    /**
      * Replaces the given employee {@code target} in the list with {@code editedEmployee}.
      * {@code target} must exist in the ManageHR.
      * The employee identity of {@code editedEmployee} must not be the same as another existing employee in ManageHR.

--- a/src/main/java/seedu/address/model/employee/UniqueEmployeeList.java
+++ b/src/main/java/seedu/address/model/employee/UniqueEmployeeList.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -165,6 +166,32 @@ public class UniqueEmployeeList implements Iterable<Employee> {
 
 
         internalList.setAll(people);
+    }
+
+    /**
+     * Adds an employee to the internal list without applying constraints.
+     * This method is intended for use when adding an employee where constraints related to the
+     * supervisor-subordinate relationship are not enforced.
+     *
+     * @param toAdd The employee to be added. Must not be {@code null}.
+     */
+    public void addWithoutConstraints(Employee toAdd) {
+        internalList.add(toAdd);
+    }
+
+    /**
+     * Enforces constraints on the internal list of employees.
+     * This method filters the internal list to include only employees who meet specific constraints.
+     * The constraints applied ensures the supervisor-subordinate relationship is enforced.
+     *
+     * @return A list of employees who does not violate the constraints.
+     */
+    public List<Employee> enforceConstraints() {
+        List<Employee> filteredList = internalList.stream()
+                .filter(x -> this.hasSubordinates(x) && this.containsManager(x))
+                .collect(Collectors.toList());
+        return filteredList;
+
     }
 
     /**

--- a/src/main/java/seedu/address/storage/JsonSerializableManageHr.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableManageHr.java
@@ -66,8 +66,9 @@ class JsonSerializableManageHr {
             if (manageHR.hasEmployee(employee)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_EMPLOYEE);
             }
-            manageHR.addEmployee(employee);
+            manageHR.addEmployeeFromStorageWithoutConstraints(employee);
         }
+        manageHR.enforceConstraints();
         return manageHR;
     }
 


### PR DESCRIPTION
When an employee has supervisors that are added at a later stage, the app will fail to relaunch when it is restarted.

This prevents the user from using the app at all.

In order to address this problem, the app first reads data from the JSON file without enforcing any constraints. Only when all the data is loaded, will the constraints be enforced.

The issue lies in ensuring that the supervisors need to exist before any employees can be under the charge of that employee. Since supervisors could also locate be located at the tail-end of the data file, our current implementation fails to take this into account.

closes #111 